### PR TITLE
Add DTOs and MapStruct mapping for project entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,19 @@
 			<artifactId>postgresql</artifactId>
 			<version>42.7.2</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct-processor</artifactId>
+			<version>1.5.5.Final</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -77,6 +90,23 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<source>21</source>
+					<target>21</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.5.5.Final</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/gutkoski/trustscore/controller/ProductController.java
+++ b/src/main/java/com/gutkoski/trustscore/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.gutkoski.trustscore.controller;
 
-import com.gutkoski.trustscore.entity.Product;
+import com.gutkoski.trustscore.dto.ProductRequestDTO;
+import com.gutkoski.trustscore.dto.ProductResponseDTO;
 import com.gutkoski.trustscore.service.interfaces.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -28,29 +29,35 @@ public class ProductController {
     }
 
     @PostMapping
-    public ResponseEntity<Product> createProduct(@RequestBody Product product) {
-        Product createdProduct = productService.createProduct(product);
-        return new ResponseEntity<>(createdProduct, HttpStatus.CREATED);
+    public ResponseEntity<ProductResponseDTO> createProduct(@RequestBody ProductRequestDTO productRequestDTO) {
+        return new ResponseEntity<>(
+                productService.createProduct(productRequestDTO),
+                HttpStatus.CREATED
+        );
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Product> getProductById(@PathVariable Long id) {
-        Product product = productService.getProductById(id);
-        return ResponseEntity.ok(product);
+    public ResponseEntity<ProductResponseDTO> getProductById(@PathVariable Long id) {
+        return ResponseEntity.ok(
+                productService.getProductById(id)
+        );
     }
 
     @GetMapping
-    public ResponseEntity<List<Product>> getAllProducts() {
-        return ResponseEntity.ok(productService.getAllProducts());
+    public ResponseEntity<List<ProductResponseDTO>> getAllProducts() {
+        return ResponseEntity.ok(
+                productService.getAllProducts()
+        );
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Product> updateProduct(
+    public ResponseEntity<ProductResponseDTO> updateProduct(
             @PathVariable Long id,
-            @RequestBody Product updatedProduct
+            @RequestBody ProductRequestDTO productRequestDTO
     ) {
-        Product product = productService.updateProduct(id, updatedProduct);
-        return ResponseEntity.ok(product);
+        return ResponseEntity.ok(
+                productService.updateProduct(id, productRequestDTO)
+        );
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/gutkoski/trustscore/controller/ProductController.java
+++ b/src/main/java/com/gutkoski/trustscore/controller/ProductController.java
@@ -1,5 +1,7 @@
-package com.gutkoski.trustscore.entities.product;
+package com.gutkoski.trustscore.controller;
 
+import com.gutkoski.trustscore.entity.Product;
+import com.gutkoski.trustscore.service.interfaces.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/gutkoski/trustscore/controller/ReviewController.java
+++ b/src/main/java/com/gutkoski/trustscore/controller/ReviewController.java
@@ -1,5 +1,7 @@
 package com.gutkoski.trustscore.controller;
 
+import com.gutkoski.trustscore.dto.ReviewRequestDTO;
+import com.gutkoski.trustscore.dto.ReviewResponseDTO;
 import com.gutkoski.trustscore.entity.Review;
 import com.gutkoski.trustscore.service.interfaces.ReviewService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,29 +29,32 @@ public class ReviewController {
     }
 
     @PostMapping
-    public ResponseEntity<Review> createReview(@RequestBody Review review) {
-        Review createdReview = reviewService.createReview(review);
-        return new ResponseEntity<>(createdReview, HttpStatus.CREATED);
+    public ResponseEntity<ReviewResponseDTO> createReview(@RequestBody ReviewRequestDTO reviewRequestDTO) {
+        ReviewResponseDTO createdReview = reviewService.createReview(reviewRequestDTO);
+        return new ResponseEntity<>(
+                createdReview,
+                HttpStatus.CREATED
+        );
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Review> getReviewById(@PathVariable Long id) {
-        Review review = reviewService.getReviewById(id);
+    public ResponseEntity<ReviewResponseDTO> getReviewById(@PathVariable Long id) {
+        ReviewResponseDTO review = reviewService.getReviewById(id);
         return ResponseEntity.ok(review);
     }
 
     @GetMapping
-    public ResponseEntity<List<Review>> getAllReviews() {
+    public ResponseEntity<List<ReviewResponseDTO>> getAllReviews() {
         return ResponseEntity.ok(reviewService.getAllReviews());
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Review> updateReview(
+    public ResponseEntity<ReviewResponseDTO> updateReview(
             @PathVariable Long id,
-            @RequestBody Review updatedReview
+            @RequestBody ReviewRequestDTO updatedReview
     ) {
-        Review review = reviewService.updateReview(id, updatedReview);
-        return ResponseEntity.ok(review);
+        ReviewResponseDTO reviewResponseDTO = reviewService.updateReview(id, updatedReview);
+        return ResponseEntity.ok(reviewResponseDTO);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/gutkoski/trustscore/controller/ReviewController.java
+++ b/src/main/java/com/gutkoski/trustscore/controller/ReviewController.java
@@ -1,5 +1,7 @@
-package com.gutkoski.trustscore.entities.review;
+package com.gutkoski.trustscore.controller;
 
+import com.gutkoski.trustscore.entity.Review;
+import com.gutkoski.trustscore.service.interfaces.ReviewService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/gutkoski/trustscore/controller/UserController.java
+++ b/src/main/java/com/gutkoski/trustscore/controller/UserController.java
@@ -1,7 +1,8 @@
-package com.gutkoski.trustscore.entities.user;
+package com.gutkoski.trustscore.controller;
 
-import com.gutkoski.trustscore.entities.user.dto.UserRequestDTO;
-import com.gutkoski.trustscore.entities.user.dto.UserResponseDTO;
+import com.gutkoski.trustscore.dto.UserRequestDTO;
+import com.gutkoski.trustscore.dto.UserResponseDTO;
+import com.gutkoski.trustscore.service.interfaces.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/gutkoski/trustscore/dto/ProductDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/dto/ProductDTO.java
@@ -1,4 +1,0 @@
-package com.gutkoski.trustscore.dto;
-
-public class ProductDTO {
-}

--- a/src/main/java/com/gutkoski/trustscore/dto/ProductDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/dto/ProductDTO.java
@@ -1,0 +1,4 @@
+package com.gutkoski.trustscore.dto;
+
+public class ProductDTO {
+}

--- a/src/main/java/com/gutkoski/trustscore/dto/ProductRequestDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/dto/ProductRequestDTO.java
@@ -1,0 +1,5 @@
+package com.gutkoski.trustscore.dto;
+
+public record ProductRequestDTO(String name,
+                                String description) {
+}

--- a/src/main/java/com/gutkoski/trustscore/dto/ProductResponseDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/dto/ProductResponseDTO.java
@@ -1,0 +1,6 @@
+package com.gutkoski.trustscore.dto;
+
+public record ProductResponseDTO(Long id,
+                                 String name,
+                                 String description) {
+}

--- a/src/main/java/com/gutkoski/trustscore/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/dto/ReviewRequestDTO.java
@@ -1,0 +1,10 @@
+package com.gutkoski.trustscore.dto;
+
+import java.time.LocalDateTime;
+
+public record ReviewRequestDTO(Integer rating,
+                               String comment,
+                               LocalDateTime date,
+                               Long productId,
+                               Long userId) {
+}

--- a/src/main/java/com/gutkoski/trustscore/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/dto/ReviewResponseDTO.java
@@ -1,0 +1,11 @@
+package com.gutkoski.trustscore.dto;
+
+import java.time.LocalDateTime;
+
+public record ReviewResponseDTO(Long id,
+                                Integer rating,
+                                String comment,
+                                LocalDateTime date,
+                                ProductResponseDTO productResponseDTO,
+                                UserResponseDTO userResponseDTO) {
+}

--- a/src/main/java/com/gutkoski/trustscore/dto/UserRequestDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/dto/UserRequestDTO.java
@@ -1,4 +1,4 @@
-package com.gutkoski.trustscore.entities.user.dto;
+package com.gutkoski.trustscore.dto;
 
 public record UserRequestDTO(String name,
                              String email) {

--- a/src/main/java/com/gutkoski/trustscore/dto/UserResponseDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/dto/UserResponseDTO.java
@@ -1,4 +1,4 @@
-package com.gutkoski.trustscore.entities.user.dto;
+package com.gutkoski.trustscore.dto;
 
 public record UserResponseDTO(Long id,
                               String name,

--- a/src/main/java/com/gutkoski/trustscore/entities/product/ProductDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/entities/product/ProductDTO.java
@@ -1,4 +1,0 @@
-package com.gutkoski.trustscore.entities.product;
-
-public class ProductDTO {
-}

--- a/src/main/java/com/gutkoski/trustscore/entities/user/UserController.java
+++ b/src/main/java/com/gutkoski/trustscore/entities/user/UserController.java
@@ -1,5 +1,7 @@
 package com.gutkoski.trustscore.entities.user;
 
+import com.gutkoski.trustscore.entities.user.dto.UserRequestDTO;
+import com.gutkoski.trustscore.entities.user.dto.UserResponseDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,29 +28,29 @@ public class UserController {
     }
 
     @PostMapping
-    public ResponseEntity<User> createUser(@RequestBody User user) {
-        User createdUser = userService.createUser(user);
+    public ResponseEntity<UserResponseDTO> createUser(@RequestBody UserRequestDTO userRequestDTO) {
+        UserResponseDTO createdUser = userService.createUser(userRequestDTO);
         return new ResponseEntity<>(createdUser, HttpStatus.CREATED);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<User> getUserById(@PathVariable Long id) {
-        User user = userService.getUserById(id);
-        return ResponseEntity.ok(user);
+    public ResponseEntity<UserResponseDTO> getUserById(@PathVariable Long id) {
+        UserResponseDTO userResponseDTO = userService.getUserById(id);
+        return ResponseEntity.ok(userResponseDTO);
     }
 
     @GetMapping
-    public ResponseEntity<List<User>> getAllUsers() {
+    public ResponseEntity<List<UserResponseDTO>> getAllUsers() {
         return ResponseEntity.ok(userService.getAllUsers());
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<User> updateUser(
+    public ResponseEntity<UserResponseDTO> updateUser(
             @PathVariable Long id,
-            @RequestBody User updatedUser
+            @RequestBody UserRequestDTO updatedUser
     ) {
-        User user = userService.updateUser(id, updatedUser);
-        return ResponseEntity.ok(user);
+        UserResponseDTO userResponseDTO = userService.updateUser(id, updatedUser);
+        return ResponseEntity.ok(userResponseDTO);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/gutkoski/trustscore/entities/user/UserService.java
+++ b/src/main/java/com/gutkoski/trustscore/entities/user/UserService.java
@@ -1,11 +1,14 @@
 package com.gutkoski.trustscore.entities.user;
 
+import com.gutkoski.trustscore.entities.user.dto.UserRequestDTO;
+import com.gutkoski.trustscore.entities.user.dto.UserResponseDTO;
+
 import java.util.List;
 
 public interface UserService {
-    User createUser(User user);
-    User getUserById(Long id);
-    List<User> getAllUsers();
-    User updateUser(Long id, User user);
+    UserResponseDTO createUser(UserRequestDTO userRequestDTO);
+    UserResponseDTO getUserById(Long id);
+    List<UserResponseDTO> getAllUsers();
+    UserResponseDTO updateUser(Long id, UserRequestDTO userRequestDTO);
     void deleteUser(Long id);
 }

--- a/src/main/java/com/gutkoski/trustscore/entities/user/UserServiceImpl.java
+++ b/src/main/java/com/gutkoski/trustscore/entities/user/UserServiceImpl.java
@@ -1,42 +1,57 @@
 package com.gutkoski.trustscore.entities.user;
 
+import com.gutkoski.trustscore.entities.user.dto.UserRequestDTO;
+import com.gutkoski.trustscore.entities.user.dto.UserResponseDTO;
+import com.gutkoski.trustscore.entities.user.mapper.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final UserMapper userMapper;
 
     @Autowired
-    public UserServiceImpl(UserRepository userRepository) {
+    public UserServiceImpl(UserRepository userRepository,
+                           UserMapper userMapper) {
         this.userRepository = userRepository;
+        this.userMapper = userMapper;
     }
 
     @Override
-    public User createUser(User user) {
-        return userRepository.save(user);
+    public UserResponseDTO createUser(UserRequestDTO userRequestDTO) {
+        User user = userMapper.toEntity(userRequestDTO);
+        User savedUser = userRepository.save(user);
+        return userMapper.toDTO(savedUser);
     }
 
     @Override
-    public User getUserById(Long id) {
-        return userRepository.findById(id)
+    public UserResponseDTO getUserById(Long id) {
+        User existingUser = userRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("User not found with id " + id));
+        return userMapper.toDTO(existingUser);
     }
 
     @Override
-    public List<User> getAllUsers() {
-        return userRepository.findAll();
+    public List<UserResponseDTO> getAllUsers() {
+        return userRepository.findAll()
+                .stream()
+                .map(userMapper::toDTO)
+                .collect(Collectors.toList());
     }
 
     @Override
-    public User updateUser(Long id, User user) {
-        User existingUser = getUserById(id);
-        existingUser.setName(user.getName());
-        existingUser.setEmail(user.getEmail());
-        return userRepository.save(existingUser);
+    public UserResponseDTO updateUser(Long id, UserRequestDTO userRequestDTO) {
+        User existingUser = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found with id " + id));
+        existingUser.setName(existingUser.getName());
+        existingUser.setEmail(existingUser.getEmail());
+        User updatedUser = userRepository.save(existingUser);
+        return userMapper.toDTO(updatedUser);
     }
 
     @Override

--- a/src/main/java/com/gutkoski/trustscore/entities/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/entities/user/dto/UserRequestDTO.java
@@ -1,0 +1,5 @@
+package com.gutkoski.trustscore.entities.user.dto;
+
+public record UserRequestDTO(String name,
+                             String email) {
+}

--- a/src/main/java/com/gutkoski/trustscore/entities/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/gutkoski/trustscore/entities/user/dto/UserResponseDTO.java
@@ -1,0 +1,6 @@
+package com.gutkoski.trustscore.entities.user.dto;
+
+public record UserResponseDTO(Long id,
+                              String name,
+                              String email) {
+}

--- a/src/main/java/com/gutkoski/trustscore/entities/user/mapper/UserMapper.java
+++ b/src/main/java/com/gutkoski/trustscore/entities/user/mapper/UserMapper.java
@@ -1,0 +1,17 @@
+package com.gutkoski.trustscore.entities.user.mapper;
+
+import com.gutkoski.trustscore.entities.user.User;
+import com.gutkoski.trustscore.entities.user.dto.UserRequestDTO;
+import com.gutkoski.trustscore.entities.user.dto.UserResponseDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+
+    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+    UserResponseDTO toDTO(User user);
+
+    User toEntity(UserRequestDTO userRequestDTO);
+}

--- a/src/main/java/com/gutkoski/trustscore/entity/Product.java
+++ b/src/main/java/com/gutkoski/trustscore/entity/Product.java
@@ -1,4 +1,5 @@
-package com.gutkoski.trustscore.entities.user;
+package com.gutkoski.trustscore.entity;
+
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,8 +9,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "users")
-public class User {
+@Table(name = "products")
+public class Product {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -17,10 +18,9 @@ public class User {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
-    private String email;
+    private String description;
 
-    public User() {
+    public Product() {
     }
 
     public Long getId() {
@@ -35,11 +35,11 @@ public class User {
         this.name = name;
     }
 
-    public String getEmail() {
-        return email;
+    public String getDescription() {
+        return description;
     }
 
-    public void setEmail(String email) {
-        this.email = email;
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/src/main/java/com/gutkoski/trustscore/entity/Review.java
+++ b/src/main/java/com/gutkoski/trustscore/entity/Review.java
@@ -1,7 +1,5 @@
-package com.gutkoski.trustscore.entities.review;
+package com.gutkoski.trustscore.entity;
 
-import com.gutkoski.trustscore.entities.product.Product;
-import com.gutkoski.trustscore.entities.user.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;

--- a/src/main/java/com/gutkoski/trustscore/entity/User.java
+++ b/src/main/java/com/gutkoski/trustscore/entity/User.java
@@ -1,5 +1,4 @@
-package com.gutkoski.trustscore.entities.product;
-
+package com.gutkoski.trustscore.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,8 +8,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "products")
-public class Product {
+@Table(name = "users")
+public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -18,9 +17,10 @@ public class Product {
     @Column(nullable = false)
     private String name;
 
-    private String description;
+    @Column(nullable = false)
+    private String email;
 
-    public Product() {
+    public User() {
     }
 
     public Long getId() {
@@ -35,11 +35,11 @@ public class Product {
         this.name = name;
     }
 
-    public String getDescription() {
-        return description;
+    public String getEmail() {
+        return email;
     }
 
-    public void setDescription(String description) {
-        this.description = description;
+    public void setEmail(String email) {
+        this.email = email;
     }
 }

--- a/src/main/java/com/gutkoski/trustscore/mapper/ProductMapper.java
+++ b/src/main/java/com/gutkoski/trustscore/mapper/ProductMapper.java
@@ -1,0 +1,17 @@
+package com.gutkoski.trustscore.mapper;
+
+import com.gutkoski.trustscore.dto.ProductRequestDTO;
+import com.gutkoski.trustscore.dto.ProductResponseDTO;
+import com.gutkoski.trustscore.entity.Product;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface ProductMapper {
+
+    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+    ProductResponseDTO toDTO(Product product);
+
+    Product toEntity(ProductRequestDTO productRequestDTO);
+}

--- a/src/main/java/com/gutkoski/trustscore/mapper/ReviewMapper.java
+++ b/src/main/java/com/gutkoski/trustscore/mapper/ReviewMapper.java
@@ -1,0 +1,22 @@
+package com.gutkoski.trustscore.mapper;
+
+import com.gutkoski.trustscore.dto.ReviewRequestDTO;
+import com.gutkoski.trustscore.dto.ReviewResponseDTO;
+import com.gutkoski.trustscore.entity.Review;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring", uses = {UserMapper.class, ProductMapper.class})
+public interface ReviewMapper {
+
+    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+    @Mapping(source = "user", target = "user")
+    @Mapping(source = "product", target = "product")
+    ReviewResponseDTO toDTO(Review review);
+
+    @Mapping(source = "userId", target = "user.id")
+    @Mapping(source = "productId", target = "product.id")
+    Review toEntity(ReviewRequestDTO reviewRequestDTO);
+}

--- a/src/main/java/com/gutkoski/trustscore/mapper/UserMapper.java
+++ b/src/main/java/com/gutkoski/trustscore/mapper/UserMapper.java
@@ -1,8 +1,8 @@
-package com.gutkoski.trustscore.entities.user.mapper;
+package com.gutkoski.trustscore.mapper;
 
-import com.gutkoski.trustscore.entities.user.User;
-import com.gutkoski.trustscore.entities.user.dto.UserRequestDTO;
-import com.gutkoski.trustscore.entities.user.dto.UserResponseDTO;
+import com.gutkoski.trustscore.entity.User;
+import com.gutkoski.trustscore.dto.UserRequestDTO;
+import com.gutkoski.trustscore.dto.UserResponseDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 

--- a/src/main/java/com/gutkoski/trustscore/repository/ProductRepository.java
+++ b/src/main/java/com/gutkoski/trustscore/repository/ProductRepository.java
@@ -1,5 +1,6 @@
-package com.gutkoski.trustscore.entities.product;
+package com.gutkoski.trustscore.repository;
 
+import com.gutkoski.trustscore.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/gutkoski/trustscore/repository/ReviewRepository.java
+++ b/src/main/java/com/gutkoski/trustscore/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
-package com.gutkoski.trustscore.entities.review;
+package com.gutkoski.trustscore.repository;
 
+import com.gutkoski.trustscore.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/gutkoski/trustscore/repository/UserRepository.java
+++ b/src/main/java/com/gutkoski/trustscore/repository/UserRepository.java
@@ -1,5 +1,6 @@
-package com.gutkoski.trustscore.entities.user;
+package com.gutkoski.trustscore.repository;
 
+import com.gutkoski.trustscore.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/gutkoski/trustscore/service/ProductServiceImpl.java
+++ b/src/main/java/com/gutkoski/trustscore/service/ProductServiceImpl.java
@@ -1,5 +1,8 @@
-package com.gutkoski.trustscore.entities.product;
+package com.gutkoski.trustscore.service;
 
+import com.gutkoski.trustscore.entity.Product;
+import com.gutkoski.trustscore.repository.ProductRepository;
+import com.gutkoski.trustscore.service.interfaces.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/gutkoski/trustscore/service/ReviewServiceImpl.java
+++ b/src/main/java/com/gutkoski/trustscore/service/ReviewServiceImpl.java
@@ -1,5 +1,8 @@
-package com.gutkoski.trustscore.entities.review;
+package com.gutkoski.trustscore.service;
 
+import com.gutkoski.trustscore.entity.Review;
+import com.gutkoski.trustscore.repository.ReviewRepository;
+import com.gutkoski.trustscore.service.interfaces.ReviewService;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/src/main/java/com/gutkoski/trustscore/service/ReviewServiceImpl.java
+++ b/src/main/java/com/gutkoski/trustscore/service/ReviewServiceImpl.java
@@ -1,7 +1,14 @@
 package com.gutkoski.trustscore.service;
 
+import com.gutkoski.trustscore.dto.ReviewRequestDTO;
+import com.gutkoski.trustscore.dto.ReviewResponseDTO;
+import com.gutkoski.trustscore.entity.Product;
 import com.gutkoski.trustscore.entity.Review;
+import com.gutkoski.trustscore.entity.User;
+import com.gutkoski.trustscore.mapper.ReviewMapper;
+import com.gutkoski.trustscore.repository.ProductRepository;
 import com.gutkoski.trustscore.repository.ReviewRepository;
+import com.gutkoski.trustscore.repository.UserRepository;
 import com.gutkoski.trustscore.service.interfaces.ReviewService;
 import org.springframework.stereotype.Service;
 
@@ -11,36 +18,65 @@ import java.util.List;
 public class ReviewServiceImpl implements ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final ReviewMapper reviewMapper;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
 
-    public ReviewServiceImpl(ReviewRepository reviewRepository) {
+    public ReviewServiceImpl(ReviewRepository reviewRepository,
+                             ReviewMapper reviewMapper,
+                             UserRepository userRepository,
+                             ProductRepository productRepository) {
         this.reviewRepository = reviewRepository;
+        this.reviewMapper = reviewMapper;
+        this.userRepository = userRepository;
+        this.productRepository = productRepository;
     }
 
     @Override
-    public Review createReview(Review review) {
-        return reviewRepository.save(review);
+    public ReviewResponseDTO createReview(ReviewRequestDTO reviewRequestDTO) {
+        Review review = reviewMapper.toEntity(reviewRequestDTO);
+        return reviewMapper.toDTO(
+                reviewRepository.save(review)
+        );
     }
 
     @Override
-    public Review getReviewById(Long id) {
-        return reviewRepository.findById(id)
+    public ReviewResponseDTO getReviewById(Long id) {
+        Review existingReview = reviewRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Review not found with id " + id));
+        return reviewMapper.toDTO(existingReview);
     }
 
     @Override
-    public List<Review> getAllReviews() {
-        return reviewRepository.findAll();
+    public List<ReviewResponseDTO> getAllReviews() {
+        return reviewRepository.findAll()
+                .stream()
+                .map(reviewMapper::toDTO)
+                .toList();
     }
 
     @Override
-    public Review updateReview(Long id, Review review) {
-        Review existingReview = getReviewById(id);
-//        existingReview.
-        return null;
+    public ReviewResponseDTO updateReview(Long id, ReviewRequestDTO reviewRequestDTO) {
+        Review existingReview = reviewRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Review not found with id " + id));
+        existingReview.setComment(reviewRequestDTO.comment());
+        existingReview.setDate(reviewRequestDTO.date());
+        existingReview.setRating(reviewRequestDTO.rating());
+
+        User user = userRepository.findById(reviewRequestDTO.userId())
+                .orElseThrow(() -> new RuntimeException("User not found with id " + reviewRequestDTO.userId()));
+        Product product = productRepository.findById(reviewRequestDTO.productId())
+                .orElseThrow(() -> new RuntimeException("Product not found with id " + reviewRequestDTO.productId()));
+
+        existingReview.setUser(user);
+        existingReview.setProduct(product);
+        return reviewMapper.toDTO(
+                reviewRepository.save(existingReview)
+        );
     }
 
     @Override
     public void deleteReview(Long id) {
-
+        reviewRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/gutkoski/trustscore/service/UserServiceImpl.java
+++ b/src/main/java/com/gutkoski/trustscore/service/UserServiceImpl.java
@@ -51,8 +51,8 @@ public class UserServiceImpl implements UserService {
     public UserResponseDTO updateUser(Long id, UserRequestDTO userRequestDTO) {
         User existingUser = userRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("User not found with id " + id));
-        existingUser.setName(existingUser.getName());
-        existingUser.setEmail(existingUser.getEmail());
+        existingUser.setName(userRequestDTO.name());
+        existingUser.setEmail(userRequestDTO.email());
         User updatedUser = userRepository.save(existingUser);
         return userMapper.toDTO(updatedUser);
     }

--- a/src/main/java/com/gutkoski/trustscore/service/UserServiceImpl.java
+++ b/src/main/java/com/gutkoski/trustscore/service/UserServiceImpl.java
@@ -1,8 +1,11 @@
-package com.gutkoski.trustscore.entities.user;
+package com.gutkoski.trustscore.service;
 
-import com.gutkoski.trustscore.entities.user.dto.UserRequestDTO;
-import com.gutkoski.trustscore.entities.user.dto.UserResponseDTO;
-import com.gutkoski.trustscore.entities.user.mapper.UserMapper;
+import com.gutkoski.trustscore.dto.UserRequestDTO;
+import com.gutkoski.trustscore.dto.UserResponseDTO;
+import com.gutkoski.trustscore.entity.User;
+import com.gutkoski.trustscore.mapper.UserMapper;
+import com.gutkoski.trustscore.repository.UserRepository;
+import com.gutkoski.trustscore.service.interfaces.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/gutkoski/trustscore/service/interfaces/ProductService.java
+++ b/src/main/java/com/gutkoski/trustscore/service/interfaces/ProductService.java
@@ -1,4 +1,6 @@
-package com.gutkoski.trustscore.entities.product;
+package com.gutkoski.trustscore.service.interfaces;
+
+import com.gutkoski.trustscore.entity.Product;
 
 import java.util.List;
 

--- a/src/main/java/com/gutkoski/trustscore/service/interfaces/ProductService.java
+++ b/src/main/java/com/gutkoski/trustscore/service/interfaces/ProductService.java
@@ -1,13 +1,14 @@
 package com.gutkoski.trustscore.service.interfaces;
 
-import com.gutkoski.trustscore.entity.Product;
+import com.gutkoski.trustscore.dto.ProductRequestDTO;
+import com.gutkoski.trustscore.dto.ProductResponseDTO;
 
 import java.util.List;
 
 public interface ProductService {
-    Product createProduct(Product product);
-    Product getProductById(Long id);
-    List<Product> getAllProducts();
-    Product updateProduct(Long id, Product product);
+    ProductResponseDTO createProduct(ProductRequestDTO productRequestDTO);
+    ProductResponseDTO getProductById(Long id);
+    List<ProductResponseDTO> getAllProducts();
+    ProductResponseDTO updateProduct(Long id, ProductRequestDTO productRequestDTO);
     void deleteProduct(Long id);
 }

--- a/src/main/java/com/gutkoski/trustscore/service/interfaces/ReviewService.java
+++ b/src/main/java/com/gutkoski/trustscore/service/interfaces/ReviewService.java
@@ -1,4 +1,6 @@
-package com.gutkoski.trustscore.entities.review;
+package com.gutkoski.trustscore.service.interfaces;
+
+import com.gutkoski.trustscore.entity.Review;
 
 import java.util.List;
 

--- a/src/main/java/com/gutkoski/trustscore/service/interfaces/ReviewService.java
+++ b/src/main/java/com/gutkoski/trustscore/service/interfaces/ReviewService.java
@@ -1,13 +1,14 @@
 package com.gutkoski.trustscore.service.interfaces;
 
-import com.gutkoski.trustscore.entity.Review;
+import com.gutkoski.trustscore.dto.ReviewRequestDTO;
+import com.gutkoski.trustscore.dto.ReviewResponseDTO;
 
 import java.util.List;
 
 public interface ReviewService {
-    Review createReview(Review review);
-    Review getReviewById(Long id);
-    List<Review> getAllReviews();
-    Review updateReview(Long id, Review review);
+    ReviewResponseDTO createReview(ReviewRequestDTO reviewRequestDTO);
+    ReviewResponseDTO getReviewById(Long id);
+    List<ReviewResponseDTO> getAllReviews();
+    ReviewResponseDTO updateReview(Long id, ReviewRequestDTO reviewRequestDTO);
     void deleteReview(Long id);
 }

--- a/src/main/java/com/gutkoski/trustscore/service/interfaces/UserService.java
+++ b/src/main/java/com/gutkoski/trustscore/service/interfaces/UserService.java
@@ -1,7 +1,7 @@
-package com.gutkoski.trustscore.entities.user;
+package com.gutkoski.trustscore.service.interfaces;
 
-import com.gutkoski.trustscore.entities.user.dto.UserRequestDTO;
-import com.gutkoski.trustscore.entities.user.dto.UserResponseDTO;
+import com.gutkoski.trustscore.dto.UserRequestDTO;
+import com.gutkoski.trustscore.dto.UserResponseDTO;
 
 import java.util.List;
 


### PR DESCRIPTION
This pull request introduces the creation of **DTOs** (Data Transfer Objects) and mappings using the **MapStruct** library for the project's existing entities. 

#### **Main changes:**
- Added DTOs for the `User`, `Product`, and `Review` entities:
  - `UserRequestDTO` and `UserResponseDTO`
  - `ProductDTO` and `ProductResponseDTO`
  - `ReviewRequestDTO` and `ReviewResponseDTO`

- Created mappers with **MapStruct** for converting between entities and DTOs:
  - `UserMapper`
  - `ProductMapper`
  - `ReviewMapper`

- Updated services to integrate DTOs and mappers:
  - Methods for creating, updating, and retrieving data now use DTOs to decouple domain entities.

#### **Motivation:**
- Improve separation of concerns in the project.
- Facilitate data handling and transfer between application layers.
- Prepare the code for future integrations with front-end or external APIs.